### PR TITLE
Add patch state change events to event log API

### DIFF
--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -169,7 +169,7 @@ Events
 .. http:get:: /api/1.0/projects/(string: linkname)/events/
 .. http:get:: /api/1.0/projects/(int: project_id)/events/
 
-    List of events for this project.
+    List of events for this project. There is a specific list for each event.
 
     .. sourcecode:: http
 
@@ -186,6 +186,42 @@ Events
         {
             "count": 23,
             "next": "http://patchwork.example.com/api/1.0/events/?page=2",
+            "previous": null,
+            "results": [
+                {
+                    "id": 2,
+                    "name": "patch-state-change"
+                },
+                {
+                    "id": 1,
+                    "name": "series-new-revision"
+                }
+            ]
+        }
+
+New Series Revision
+~~~~~~
+
+.. http:get:: /api/1.0/projects/(string: linkname)/newrevisions/
+.. http:get:: /api/1.0/projects/(int: project_id)/newrevisions/
+
+    List of new Series Revision events recorded for this project.
+
+    .. sourcecode:: http
+
+        GET /api/1.0/projects/intel-gfx/newrevisions/ HTTP/1.1
+        Accept: application/json
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+        Vary: Accept
+        Allow: GET, HEAD, OPTIONS
+
+        {
+            "count": 23,
+            "next": "http://patchwork.example.com/api/1.0/newrevisions/?page=2",
             "previous": null,
             "results": [
                 {
@@ -217,8 +253,7 @@ Events
                   be used in the next query with a ``since`` parameter to only
                   retrieve events that haven't been seen yet.
 
-Each event type has some ``parameters`` specific to that event. At the moment,
-only one event is possible:
+Each new Series Revision event has some specific ``parameters``.
 
 - **series-new-revision**: This event corresponds to patchwork receiving a new
   revision of a series, should it be the initial submission or subsequent
@@ -232,6 +267,49 @@ only one event is possible:
   ``series`` and ``revision`` can be used to retrieve the corresponding
   patches.
 
+State Change
+~~~~~
+
+.. http:get:: /api/1.0/projects/(string: linkname)/statechanges/
+.. http:get:: /api/1.0/projects/(int: project_id)/statechanges/
+
+    List of new Patch State Change events recorded for this project.
+
+    .. sourcecode:: http
+
+        GET /api/1.0/projects/intel-gfx/statechanges/ HTTP/1.1
+        Accept: application/json
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+        Vary: Accept
+        Allow: GET, HEAD, OPTIONS
+
+        {
+            "count": 7,
+            "next": "http://patchwork.example.com/api/1.0/projects/intel-gfx/statechanges/?page=2",
+            "previous": null,
+            "results": [
+                {
+                    "name": "patch-state-change",
+                    "event_time": "2016-02-05T02:21:41.543966",
+                    "patch": 9,
+                    "user": 2,
+                    "new_state": "Changes Requested",
+                    "previous_state": "New"
+                },
+                {
+                    "name": "patch-state-change",
+                    "event_time": "2016-01-29T07:29:20.487172",
+                    "patch": 7,
+                    "user": null,
+                    "new_state": "New",
+                    "previous_state": "Under Review"
+                }
+            ]
+        }
 
 Series
 ~~~~~~

--- a/patchwork/current_user.py
+++ b/patchwork/current_user.py
@@ -1,0 +1,10 @@
+from threading import local
+
+_user = local()
+
+class CurrentUserMiddleware(object):
+    def process_request(self, request):
+        _user.value = request.user
+
+def get_current_user():
+    return _user.value

--- a/patchwork/fixtures/default_events.xml
+++ b/patchwork/fixtures/default_events.xml
@@ -3,4 +3,7 @@
   <object pk="1" model="patchwork.event">
     <field type="CharField" name="name">series-new-revision</field>
   </object>
+  <object pk="2" model="patchwork.event">
+    <field type="CharField" name="name">patch-state-change</field>
+  </object>
 </django-objects>

--- a/patchwork/serializers.py
+++ b/patchwork/serializers.py
@@ -23,7 +23,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
 from patchwork.models import Project, Series, SeriesRevision, Patch, Person, \
-                             State, EventLog, Test, TestResult, TestState
+                             State, Event, EventLog, Test, TestResult, TestState
 from rest_framework import serializers
 from rest_framework import fields
 from enum import Enum
@@ -197,7 +197,12 @@ class RevisionSerializer(PatchworkModelSerializer):
             'patches': PatchSerializer,
         }
 
-class EventLogSerializer(PatchworkModelSerializer):
+class EventSerializer(PatchworkModelSerializer):
+    class Meta:
+        model = Event 
+        fields = ('id', 'name')
+
+class NewrevisionSerializer(PatchworkModelSerializer):
     name = serializers.CharField(source='event.name', read_only=True)
     parameters = JSONField(read_only=True)
     class Meta:
@@ -205,6 +210,16 @@ class EventLogSerializer(PatchworkModelSerializer):
         fields = ('name', 'event_time', 'series', 'user', 'parameters')
         expand_serializers = {
             'series': SeriesSerializer,
+            'user': UserSerializer,
+        }
+
+class StatechangeLogSerializer(PatchworkModelSerializer):
+    name = serializers.CharField(source='event.name', read_only=True)
+    parameters = JSONField(read_only=True)
+    class Meta:
+        model = EventLog
+        fields = ('name', 'event_time', 'patch', 'user', 'new_state', 'previous_state')
+        expand_serializers = {
             'user': UserSerializer,
         }
 

--- a/patchwork/settings/base.py
+++ b/patchwork/settings/base.py
@@ -36,6 +36,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'patchwork.current_user.CurrentUserMiddleware',
 ]
 
 if django.VERSION < (1, 7):

--- a/patchwork/urls.py
+++ b/patchwork/urls.py
@@ -37,7 +37,15 @@ series_list_router.register(r'series', api.SeriesListViewSet)
 # /projects/$project/events/
 event_router = routers.NestedSimpleRouter(project_router, 'projects',
                                           lookup='project')
-event_router.register(r'events', api.EventLogViewSet)
+event_router.register(r'events', api.EventViewSet)
+# /projects/$project/newrevisions
+newrevision_router = routers.NestedSimpleRouter(project_router, 'projects',
+                                          lookup='project')
+newrevision_router.register(r'newrevisions', api.NewRevisionViewSet)
+# /projects/$project/statechanges/
+statechange_router = routers.NestedSimpleRouter(project_router, 'projects',
+                                          lookup='project')
+statechange_router.register(r'statechanges', api.StatechangeLogViewSet)
 # /series/$id/
 series_router = routers.SimpleRouter()
 series_router.register(r'series', api.SeriesViewSet)
@@ -75,6 +83,8 @@ urlpatterns = patterns('',
     (r'^api/1.0/', include(patches_router.urls)),
     (r'^api/1.0/', include(patch_results_router.urls)),
     (r'^api/1.0/', include(event_router.urls)),
+    (r'^api/1.0/', include(newrevision_router.urls)),
+    (r'^api/1.0/', include(statechange_router.urls)),
 
     # project view:
     url(r'^$', 'patchwork.views.projects', name='root'),

--- a/patchwork/views/api.py
+++ b/patchwork/views/api.py
@@ -467,10 +467,8 @@ class EventViewSet(mixins.ListModelMixin,
                       ListMixin,
                       viewsets.GenericViewSet):
     permission_classes = (MaintainerPermission, )
-    queryset = EventLog.objects.all()
+    queryset = Event.objects.all()
     serializer_class = EventSerializer
-    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
-    filter_class = EventTimeFilter
 
     def retrieve(self, request, pk=None):
         if is_integer(pk):


### PR DESCRIPTION
For issue #40: This change creates the patch State Change event and stores the related event log. The existing Event page is modified to display only available events and two new pages are created: State Change and New Series Revision to display the logs.
This change has been tested in the following staging instance (Intel network access required):
http://gdcpatchwork.amr.corp.intel.com:8000/api/1.0/projects/2/events/
http://gdcpatchwork.amr.corp.intel.com:8000/api/1.0/projects/2/newrevisions/
http://gdcpatchwork.amr.corp.intel.com:8000/api/1.0/projects/2/statechanges/

Note: Two new columns are required in the patchwork_eventlog table, that were manually added to existing db.
