### PR TITLE
Add patch-state-change event and log

### DIFF
--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -202,12 +202,14 @@ Events
                 {
                 },
                 {
-                    "name": "series-new-revision",
-                    "event_time": "2015-10-20T19:49:43.895382",
-                    "series": 22,
-                    "user": null,
+                    "name": "patch-state-change",
+                    "event_time": "2016-02-18T09:30:33.853206",
+                    "series": null,
+                    "user": 1,
                     "parameters": {
-                        "revision": 1
+                        "changed_patch": 3417,
+                        "new_state": "Under Review",
+                        "previous_state": "New"
                     }
                 }
             ]
@@ -220,7 +222,7 @@ Events
                   retrieve events that haven't been seen yet.
 
 Each event type has some ``parameters`` specific to that event. At the moment,
-only one event is possible:
+two events are possible:
 
 - **series-new-revision**: This event corresponds to patchwork receiving a new
   revision of a series, should it be the initial submission or subsequent
@@ -234,6 +236,7 @@ only one event is possible:
   ``series`` and ``revision`` can be used to retrieve the corresponding
   patches.
 
+- **patch-state-change**: This event corresponds to patchwork receiving a patch state change, either automatic or manually performed by an authorized user, who will be identified by its patchwork-user id.
 
 Series
 ~~~~~~

--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -204,10 +204,10 @@ Events
                 {
                     "name": "patch-state-change",
                     "event_time": "2016-02-18T09:30:33.853206",
-                    "series": null,
+                    "series": 285,
+                    "patch": 685
                     "user": 1,
                     "parameters": {
-                        "changed_patch": 3417,
                         "new_state": "Under Review",
                         "previous_state": "New"
                     }

--- a/patchwork/ThreadLocalRequest.py
+++ b/patchwork/ThreadLocalRequest.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+
+"""
+    threadlocals middleware
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    make the request object everywhere available (e.g. in model instance). 
+
+    based on: http://code.djangoproject.com/wiki/CookBookThreadlocalsAndUser
+    
+    Put this into your settings:   
+    --------------------------------------------------------------------------
+        MIDDLEWARE_CLASSES = (
+            ...
+            'django_tools.middlewares.ThreadLocal.ThreadLocalMiddleware',
+            ...
+        )
+    --------------------------------------------------------------------------
+    
+    
+    Usage:
+    --------------------------------------------------------------------------
+    from django_tools.middlewares import ThreadLocal
+    
+    # Get the current request object:
+    request = ThreadLocal.get_current_request()
+    
+    # You can get the current user directly with:
+    user = ThreadLocal.get_current_user()
+    --------------------------------------------------------------------------
+
+    :copyleft: 2009-2011 by the django-tools team, see AUTHORS for more details.
+    :license: GNU GPL v3 or above, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+
+
+try:
+    from threading import local
+except ImportError:
+    from django.utils._threading_local import local
+
+
+_thread_locals = local()
+
+
+def get_current_request():
+    """ returns the request object for this thread """
+    return getattr(_thread_locals, "request", None)
+
+
+def get_current_user():
+    """ returns the current user, if exist, otherwise returns None """
+    request = get_current_request()
+    if request:
+        return getattr(request, "user", None)
+
+
+class ThreadLocalRequestMiddleware(object):
+    """ Simple middleware that adds the request object in thread local storage."""
+    def process_request(self, request):
+        _thread_locals.request = request
+
+    def process_response(self, request, response):
+        if hasattr(_thread_locals, 'request'):
+            del _thread_locals.request
+        return response

--- a/patchwork/fixtures/default_events.xml
+++ b/patchwork/fixtures/default_events.xml
@@ -3,4 +3,7 @@
   <object pk="1" model="patchwork.event">
     <field type="CharField" name="name">series-new-revision</field>
   </object>
+  <object pk="2" model="patchwork.event">
+    <field type="CharField" name="name">patch-state-change</field>
+  </object>
 </django-objects>

--- a/patchwork/migrations/0018_eventlog_patch.py
+++ b/patchwork/migrations/0018_eventlog_patch.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patchwork', '0017_series_meta'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='eventlog',
+            name='patch',
+            field=models.ForeignKey(to='patchwork.Patch', null=True),
+        ),
+    ]

--- a/patchwork/models.py
+++ b/patchwork/models.py
@@ -673,6 +673,7 @@ class EventLog(models.Model):
     series = models.ForeignKey(Series)
     user = models.ForeignKey(User, null=True)
     parameters = jsonfield.JSONField(null=True)
+    patch = models.ForeignKey(Patch, null=True)
 
     class Meta:
         ordering = ['-event_time']
@@ -820,6 +821,7 @@ def _patch_change_callback(sender, instance, **kwargs):
     curr_user = ThreadLocalRequest.get_current_user()
     previous_state = str(orig_patch.state)
     new_state = str(instance.state)
+    changed_patch = Patch.objects.get(pk=instance.pk)
 
     # Do not log patch-state-change events for Patches that
     # are not part of a Series
@@ -828,8 +830,8 @@ def _patch_change_callback(sender, instance, **kwargs):
         log = EventLog(event=event_state_change,
                       user=curr_user,
                       series_id=series.id,
-                      parameters={'changed_patch': instance.pk,
-                                  'previous_state': previous_state,
+                      patch=changed_patch,
+                      parameters={'previous_state': previous_state,
                                   'new_state': new_state,
                                     })
         log.save()

--- a/patchwork/serializers.py
+++ b/patchwork/serializers.py
@@ -226,7 +226,7 @@ class EventLogSerializer(PatchworkModelSerializer):
 
     class Meta:
         model = EventLog
-        fields = ('name', 'event_time', 'series', 'user', 'parameters')
+        fields = ('name', 'event_time', 'series', 'patch', 'user', 'parameters')
         expand_serializers = {
             'series': SeriesSerializer,
             'user': UserSerializer,

--- a/patchwork/settings/base.py
+++ b/patchwork/settings/base.py
@@ -36,6 +36,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'patchwork.ThreadLocalRequest.ThreadLocalRequestMiddleware',
 ]
 
 if django.VERSION < (1, 7):

--- a/patchwork/tests/test_series.py
+++ b/patchwork/tests/test_series.py
@@ -21,7 +21,8 @@ import os
 
 from django.test import TestCase
 from patchwork.models import Patch, Series, SeriesRevision, Project, \
-                             SERIES_DEFAULT_NAME, EventLog, User, Person
+                             SERIES_DEFAULT_NAME, EventLog, User, Person, \
+                             State
 from patchwork.tests.utils import read_mail
 from patchwork.tests.utils import defaults, read_mail, TestSeries
 
@@ -659,3 +660,21 @@ class EventLogIncompleteTest(MultipleMailCoverLetterSeriesIncomplete):
     def testNoNewSeriesIfIncomplete(self):
         logs = EventLog.objects.all()
         self.assertEquals(logs.count(), 0)
+
+#
+# patch-state-change event tests
+#
+
+class StateChangeEventLogTest(SingleMailSeries):
+    def testStateChangeLog(self):
+        patches = Patch.objects.all()
+        states = [patch.state.pk for patch in patches]
+        state = State.objects.exclude(pk__in = states)[0]
+        update_count = 0
+        for patch in patches:
+            patch.state=state
+            patch.save()
+            update_count += 1
+        stateChangeLogCount = EventLog.objects.filter(event_id=2).count()
+        self.assertEquals(update_count, stateChangeLogCount)
+


### PR DESCRIPTION
Add the patch-state-change event and corresponding log to API. Update documentation accordingly and add unit test.
As requested in issue #140 
