### PR TITLE
git-pw: Search for git repo in parent directories during setup

### DIFF
--- a/git-pw/git-pw
+++ b/git-pw/git-pw
@@ -499,7 +499,7 @@ class GitPatchwork(object):
 
     def setup(self):
         try:
-            self.repo = git.Repo(os.getcwd())
+            self.repo = git.Repo(os.getcwd(), search_parent_directories=True)
         except git.exc.InvalidGitRepositoryError:
             if self.cmd.need_git_repo:
                 die('Not a git repository.')

--- a/git-pw/requirements.txt
+++ b/git-pw/requirements.txt
@@ -1,2 +1,2 @@
-GitPython
+GitPython >= 0.3.5
 requests


### PR DESCRIPTION
Running git-pw from a subdirectory of a repo would fail with

```
fatal: Not a git repository.
```

This is inconsistent with most git tools, so fix this by passing
search_parent_directories=True to git.Repo().

Signed-off-by: Ander Conselvan de Oliveira ander.conselvan.de.oliveira@intel.com

---

I'm not sure this is worth the extra dependency though. I couldn't find any way to query GitPython's version and only set the parameter if the version is at least 0.3.5.
