### PR TITLE
parsemail: Allow new series creation with pull-request messages

### DIFF
--- a/docs/requirements-dev.txt
+++ b/docs/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements-base.txt
-django-debug-toolbar
+django-debug-toolbar==1.4
 selenium
 sphinx
 sphinxcontrib-httpdomain

--- a/patchwork/bin/parsemail.py
+++ b/patchwork/bin/parsemail.py
@@ -396,9 +396,10 @@ def find_content(project, mail):
         project.git_send_email_only and not is_git_send_email(mail)
 
     if pullurl or (is_patch and not drop_patch):
-        ret.patch_order = x or 1
-        ret.patch = Patch(name=name, pull_url=pullurl, content=patchbuf,
-                          date=mail_date(mail), headers=mail_headers(mail))
+        if project.git_send_email_only or not is_cover_letter:
+            ret.patch_order = x or 1
+            ret.patch = Patch(name=name, pull_url=pullurl, content=patchbuf,
+                              date=mail_date(mail), headers=mail_headers(mail))
 
     if patchbuf:
         ret.filenames = patch_get_filenames(patchbuf)


### PR DESCRIPTION
Series are not properly created in projects that do not allow
patches submitted with git pull request utility for this purpose.
This change allows such method for projects that are not set
as git_send_email_only.
[Issue #190]

Signed-off-by: Jose Lamego jose.a.lamego@linux.intel.com
