### PR TITLE
docs/requirements-dev.txt: require django-debug-toolbar ver. 1.4

### DIFF
--- a/docs/requirements-dev.txt
+++ b/docs/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements-base.txt
-django-debug-toolbar
+django-debug-toolbar==1.4
 selenium
 sphinx
 sphinxcontrib-httpdomain


### PR DESCRIPTION
django-debug-toolbar version 1.5 requires django 1.8+, thus
producting an error with current dev-environment configuration.
This fix requires version 1.4 to be used instead.

[ISSUE #198]

Signed-off-by: Jose Lamego jose.a.lamego@linux.intel.com
