### PR TITLE
parsemail: Update user's name to the last one used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
 services:
     - mysql
 
+before_install:
+    - firefox --version
+
 install:
     - npm install jshint
     - npm install karma

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     apt:
         packages:
         - libmysqlclient-dev
+    firefox: "52.0esr"
 
 services:
     - mysql
@@ -20,6 +21,13 @@ install:
     - npm install karma
     - npm install karma-jasmine
     - npm install karma-firefox-launcher
+
+    - wget https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz
+    - mkdir geckodriver
+    - tar -xzf geckodriver-v0.17.0-linux64.tar.gz -C geckodriver
+    - export PATH=$PATH:$PWD/geckodriver
+    - geckodriver --version
+
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
     - sleep 3 # give xvfb some time to start

--- a/docs/requirements-dev.txt
+++ b/docs/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements-base.txt
-django-debug-toolbar
+django-debug-toolbar==1.4
 selenium
 sphinx
 sphinxcontrib-httpdomain

--- a/patchwork/admin.py
+++ b/patchwork/admin.py
@@ -37,6 +37,8 @@ class ProjectAdmin(admin.ModelAdmin):
     inlines = [
         DelegationRuleInline,
     ]
+
+
 admin.site.register(Project, ProjectAdmin)
 
 
@@ -50,16 +52,22 @@ class PersonAdmin(admin.ModelAdmin):
     has_account.boolean = True
     has_account.admin_order_field = 'user'
     has_account.short_description = 'Account'
+
+
 admin.site.register(Person, PersonAdmin)
 
 
 class UserProfileAdmin(admin.ModelAdmin):
     search_fields = ('user__username', 'user__first_name', 'user__last_name')
+
+
 admin.site.register(UserProfile, UserProfileAdmin)
 
 
 class StateAdmin(admin.ModelAdmin):
     list_display = ('name', 'action_required')
+
+
 admin.site.register(State, StateAdmin)
 
 
@@ -77,6 +85,7 @@ class SeriesAdmin(admin.ModelAdmin):
     search_fields = ('name', 'submitter__name', 'submitter__email',
                      'reviewer__first_name', 'reviewer__last_name')
     date_hierarchy = 'submitted'
+
 
 admin.site.register(Series, SeriesAdmin)
 
@@ -102,6 +111,7 @@ class SeriesRevisionAdmin(admin.ModelAdmin):
     submitter_name.short_description = 'Submitter'
     submitter_name.admin_order_field = 'series__submitter__name'
 
+
 admin.site.register(SeriesRevision, SeriesRevisionAdmin)
 
 
@@ -118,6 +128,8 @@ class PatchAdmin(admin.ModelAdmin):
     is_pull_request.boolean = True
     is_pull_request.admin_order_field = 'pull_url'
     is_pull_request.short_description = 'Pull'
+
+
 admin.site.register(Patch, PatchAdmin)
 
 
@@ -125,6 +137,8 @@ class CommentAdmin(admin.ModelAdmin):
     list_display = ('patch', 'submitter', 'date')
     search_fields = ('patch__name', 'submitter__name', 'submitter__email')
     date_hierarchy = 'date'
+
+
 admin.site.register(Comment, CommentAdmin)
 
 
@@ -137,12 +151,16 @@ class EventAdmin(admin.ModelAdmin):
 
     def event_name(self, log):
         return log.event.name
+
+
 admin.site.register(EventLog, EventAdmin)
 
 
 class TestAdmin(admin.ModelAdmin):
     list_display = ('name', 'project')
     list_filter = ('project', )
+
+
 admin.site.register(Test, TestAdmin)
 
 
@@ -152,6 +170,8 @@ class TestResultAdmin(admin.ModelAdmin):
     search_fields = ('test__name', 'patch__name', 'revision__series__name',
                      'test__project__name')
     date_hierarchy = 'date'
+
+
 admin.site.register(TestResult, TestResultAdmin)
 
 
@@ -159,9 +179,13 @@ class BundleAdmin(admin.ModelAdmin):
     list_display = ('name', 'owner', 'project', 'public')
     list_filter = ('public', 'project')
     search_fields = ('name', 'owner')
+
+
 admin.site.register(Bundle, BundleAdmin)
 
 
 class TagAdmin(admin.ModelAdmin):
     list_display = ('name',)
+
+
 admin.site.register(Tag, TagAdmin)

--- a/patchwork/bin/parsemail.py
+++ b/patchwork/bin/parsemail.py
@@ -168,15 +168,18 @@ def find_author(mail):
     if name is not None:
         name = name.strip()
 
-    new_person = False
+    save_required = False
 
     try:
         person = Person.objects.get(email__iexact=email)
+        if person.name !=  name:
+            person.name = name
+            save_required = True
     except Person.DoesNotExist:
         person = Person(name=name, email=email)
-        new_person = True
+        save_required = True
 
-    return (person, new_person)
+    return (person, save_required)
 
 
 def mail_date(mail):

--- a/patchwork/bin/parsemail.py
+++ b/patchwork/bin/parsemail.py
@@ -172,7 +172,7 @@ def find_author(mail):
 
     try:
         person = Person.objects.get(email__iexact=email)
-        if person.name !=  name:
+        if person.name != name:
             person.name = name
             save_required = True
     except Person.DoesNotExist:

--- a/patchwork/bin/pwclient
+++ b/patchwork/bin/pwclient
@@ -359,6 +359,7 @@ def patch_id_from_hash(rpc, project, hash):
         sys.exit(1)
     return patch_id
 
+
 auth_actions = ['update']
 
 
@@ -735,6 +736,7 @@ def main():
         sys.stderr.write("Unknown action '%s'\n" % action)
         action_parser.print_help()
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/patchwork/filters.py
+++ b/patchwork/filters.py
@@ -407,6 +407,7 @@ class DelegateFilter(Filter):
             self.applied = False
             self.forced = True
 
+
 filterclasses = [SubmitterFilter,
                  StateFilter,
                  SearchFilter,

--- a/patchwork/forms.py
+++ b/patchwork/forms.py
@@ -256,5 +256,6 @@ class MultiplePatchForm(forms.Form):
 class EmailForm(forms.Form):
     email = forms.EmailField(max_length=200)
 
+
 UserPersonLinkForm = EmailForm
 OptinoutRequestForm = EmailForm

--- a/patchwork/models.py
+++ b/patchwork/models.py
@@ -122,6 +122,7 @@ def user_name(user):
         return u' '.join(names)
     return user.username
 
+
 auth.models.User.add_to_class('name', user_name)
 
 
@@ -203,6 +204,7 @@ def _user_saved_callback(sender, created, instance, **kwargs):
     except UserProfile.DoesNotExist:
         profile = UserProfile(user=instance)
     profile.save()
+
 
 models.signals.post_save.connect(_user_saved_callback, sender=User)
 
@@ -478,6 +480,7 @@ class BundlePatch(models.Model):
         unique_together = [('bundle', 'patch')]
         ordering = ['order']
 
+
 SERIES_DEFAULT_NAME = "Series without cover letter"
 
 
@@ -556,6 +559,7 @@ class Series(models.Model):
 
     class Meta:
         verbose_name_plural = 'Series'
+
 
 # Signal one can listen to to know when a revision is complete (ie. has all of
 # its patches)
@@ -991,5 +995,6 @@ def _on_revision_complete(sender, revision, **kwargs):
                    user=series.submitter.user,
                    parameters={'revision': revision.version})
     log.save()
+
 
 series_revision_complete.connect(_on_revision_complete)

--- a/patchwork/parser.py
+++ b/patchwork/parser.py
@@ -307,6 +307,7 @@ def main(args):
         filenames = patch_get_filenames(content)
         print("File names: ----\n" + '\n'.join(filenames))
 
+
 if __name__ == '__main__':
     import sys
     sys.exit(main(sys.argv))

--- a/patchwork/templatetags/syntax.py
+++ b/patchwork/templatetags/syntax.py
@@ -34,6 +34,7 @@ def _compile(t):
     (r, str) = t
     return (re.compile(r, re.M | re.I), str)
 
+
 _patch_span_res = list(map(_compile, [
     ('^(Index:?|diff|\-\-\-|\+\+\+|\*\*\*) .*$', 'p_header'),
     ('^\+.*$', 'p_add'),

--- a/patchwork/tests/browser.py
+++ b/patchwork/tests/browser.py
@@ -132,7 +132,13 @@ class SeleniumTestCase(StaticLiveServerTestCase):
         return self.selenium.find_element_by_css_selector(selector)
 
     def focused_element(self):
-        return self.selenium.switch_to.active_element
+        active_element = self.selenium.switch_to.active_element
+        # XXX: WA for Firefox driver
+        #      selenium does not perform w3c conformance negotiation
+        #      resulting in focused element being wrapped in a dict
+        if isinstance(active_element, dict):
+            active_element = active_element['value']
+        return active_element
 
     def wait_until_present(self, name):
         def is_present(driver):

--- a/patchwork/tests/test_lock.py
+++ b/patchwork/tests/test_lock.py
@@ -295,5 +295,6 @@ class testlock(unittest.TestCase):
 
         lock.release()
 
+
 if __name__ == '__main__':
     unittest.main(__name__)

--- a/patchwork/tests/test_patchparser.py
+++ b/patchwork/tests/test_patchparser.py
@@ -242,6 +242,10 @@ class SubjectUTF8QPMultipleEncodingTest(SubjectEncodingTest):
 
 class SenderCorrelationTest(TestCase):
     existing_sender = 'Existing Sender <existing@example.com>'
+    existing_sender_upper = 'Existing Sender <EXISTING@EXAMPLE.COM>'
+    existing_sender_new_name = 'Sender Existing <existing@example.com>'
+    existing_sender_alternate_format = 'existing@example.com (Existing Sender)'
+
     non_existing_sender = 'Non-existing Sender <nonexisting@example.com>'
 
     def mail(self, sender):
@@ -258,25 +262,31 @@ class SenderCorrelationTest(TestCase):
         self.person.save()
 
     def testExisingSender(self):
-        (person, new) = find_author(self.existing_sender_mail)
-        self.assertEqual(new, False)
+        (person, save_required) = find_author(self.existing_sender_mail)
+        self.assertEqual(save_required, False)
         self.assertEqual(person.id, self.person.id)
 
     def testNonExisingSender(self):
-        (person, new) = find_author(self.non_existing_sender_mail)
-        self.assertEqual(new, True)
+        (person, save_required) = find_author(self.non_existing_sender_mail)
+        self.assertEqual(save_required, True)
         self.assertEqual(person.id, None)
 
     def testExistingDifferentFormat(self):
-        mail = self.mail('existing@example.com')
-        (person, new) = find_author(mail)
-        self.assertEqual(new, False)
+        mail = self.mail(self.existing_sender_alternate_format)
+        (person, save_required) = find_author(mail)
+        self.assertEqual(save_required, False)
         self.assertEqual(person.id, self.person.id)
 
-    def testExistingDifferentCase(self):
-        mail = self.mail(self.existing_sender.upper())
-        (person, new) = find_author(mail)
-        self.assertEqual(new, False)
+    def testExistingDifferentEmailCase(self):
+        mail = self.mail(self.existing_sender_upper)
+        (person, save_required) = find_author(mail)
+        self.assertEqual(save_required, False)
+        self.assertEqual(person.id, self.person.id)
+
+    def testExistingUpdateName(self):
+        mail = self.mail(self.existing_sender_new_name)
+        (person, save_required) = find_author(mail)
+        self.assertEqual(save_required, True)
         self.assertEqual(person.id, self.person.id)
 
     def tearDown(self):

--- a/patchwork/tests/utils.py
+++ b/patchwork/tests/utils.py
@@ -64,6 +64,7 @@ I hope you'll like it."""
 
     review = """This is a great addition!"""
 
+
 error_strings = {
     'email': 'Enter a valid email address.',
 }

--- a/patchwork/utils.py
+++ b/patchwork/utils.py
@@ -120,6 +120,7 @@ class Order(object):
 
         return qs.order_by(*orders)
 
+
 bundle_actions = ['create', 'add', 'remove']
 
 

--- a/patchwork/views/base.py
+++ b/patchwork/views/base.py
@@ -153,6 +153,7 @@ def user_complete(request):
 
     return HttpResponse(json.dumps(data), content_type="application/json")
 
+
 help_pages = {'':           'index.html',
               'about/':     'about.html',
               }

--- a/patchwork/views/xmlrpc.py
+++ b/patchwork/views/xmlrpc.py
@@ -133,6 +133,7 @@ class PatchworkXMLRPCDispatcher(SimpleXMLRPCDispatcher,
 
         return response
 
+
 dispatcher = PatchworkXMLRPCDispatcher()
 
 # XMLRPC view function


### PR DESCRIPTION
Currently the first email patchwork picks up from an address defines
name assigned to that address. If it contains a typo it will stick and
require an admin to fix that.

Follow up mail with the name fixed does not change a thing.

Since the mboxes are recomposed using that name, the typo can stick to
multiple patches unnoticed, which seems to be the case quite often.

So let's fix that with updating Person with the latest name they used
from their email address.

Signed-off-by: Arkadiusz Hiler <arkadiusz.hiler@intel.com>