### PR TITLE
Link the series from the patch view

### DIFF
--- a/patchwork/management/commands/retriageproject.py
+++ b/patchwork/management/commands/retriageproject.py
@@ -21,16 +21,8 @@ from email.parser import HeaderParser
 import sys
 
 from django.core.management.base import BaseCommand
-from patchwork.models import Patch, Project, SeriesRevisionPatch
+from patchwork.models import Patch, Project
 from patchwork.bin.parsemail import find_project
-
-
-def find_series_for_patch(patch):
-    try:
-        revision = SeriesRevisionPatch.objects.filter(patch=patch)[0].revision
-        return revision.series
-    except:
-        return None
 
 
 class Command(BaseCommand):
@@ -65,7 +57,7 @@ class Command(BaseCommand):
 
             patch.project = new_project
             patch.save()
-            series = find_series_for_patch(patch)
+            series = patch.series()
             if not series:
                 continue
             series.project = new_project

--- a/patchwork/templates/patchwork/patch.html
+++ b/patchwork/templates/patchwork/patch.html
@@ -42,6 +42,12 @@ function toggle_headers(link_id, headers_id)
    <th>State</th>
    <td>{{ patch.state.name }}{% if patch.archived %}, archived{% endif %}</td>
   </tr>
+{% if series %}
+  <tr>
+   <th>Series</th>
+   <td><a href="{% url 'series' series=series.id %}"/>"{{ series }}"</a></td>
+  </tr>
+{% endif %}
 {% if patch.commit_ref %}
   <tr>
    <th>Commit</th>

--- a/patchwork/views/patch.py
+++ b/patchwork/views/patch.py
@@ -81,6 +81,7 @@ def patch(request, patch_id):
                 context.add_message('Patch updated')
 
     context['patch'] = patch
+    context['series'] = patch.series()
     context['patchform'] = form
     context['createbundleform'] = createbundleform
     context['project'] = patch.project


### PR DESCRIPTION
This is something me and many others find doing manually all the time - looking for the series the patch is a part of - to see other, related patches, to check on CI results, etc.

So to ease the manual labor we should just have a convenient link on the patch view :-)