### PR TITLE
parsemail: Filter subject tag basing on list's address

### DIFF
--- a/patchwork/bin/parsemail.py
+++ b/patchwork/bin/parsemail.py
@@ -387,7 +387,8 @@ def find_content(project, mail):
 
     ret = MailContent()
 
-    drop_prefixes = [project.linkname] + project.get_subject_prefix_tags()
+    drop_prefixes = [project.linkname, project.get_listemail_tag()]
+    drop_prefixes += project.get_subject_prefix_tags()
     (name, prefixes) = clean_subject(mail.get('Subject'), drop_prefixes)
     (x, n) = parse_series_marker(prefixes)
     refs = build_references_list(mail)

--- a/patchwork/models.py
+++ b/patchwork/models.py
@@ -109,6 +109,9 @@ class Project(models.Model):
     def get_subject_prefix_tags(self):
         return get_comma_separated_field(self.subject_prefix_tags)
 
+    def get_listemail_tag(self):
+        return self.listemail.split("@")[0]
+
     def __str__(self):
         return self.name
 

--- a/patchwork/tests/test_patchparser.py
+++ b/patchwork/tests/test_patchparser.py
@@ -426,6 +426,11 @@ class MultipleProjectsPerMailingListTest(TestCase):
                                 listemail='2@example.com')
         self.project2.save()
 
+        self.project3 = Project(linkname='test-project-3', name='Project 3',
+                                listid='list.example.com',
+                                listemail='3@example.com')
+        self.project3.save()
+
     def testTagList(self):
         self.project1.subject_prefix_tags = ''
         self.assertEquals(self.project1.get_subject_prefix_tags(), [])
@@ -486,6 +491,16 @@ class MultipleProjectsPerMailingListTest(TestCase):
         self.project2.save()
         email = create_email(defaults.patch, project=self.project1,
                              subject='[PATCH i-g-t] Subject')
+        parse_mail(email)
+        patch = Patch.objects.all()[0]
+        self.assertEquals(patch.name, 'Subject')
+
+    def testStripListemailTag(self):
+        self.project3.subject_prefix_tags = 'i-g-t'
+        self.project3.listemail = 'intel-gfx@example.com'
+        self.project3.save()
+        email = create_email(defaults.patch, project=self.project3,
+                             subject='[intel-gfx] [PATCH i-g-t] Subject')
         parse_mail(email)
         patch = Patch.objects.all()[0]
         self.assertEquals(patch.name, 'Subject')


### PR DESCRIPTION
Tag added by the mailing list usually matches local-part of it's email
address, so we should filter it out as well.

That helps us in the case when we have multiple project shearing a single
list.

Signed-off-by: Arkadiusz Hiler <arkadiusz.hiler@intel.com>