### PR TITLE
rest: Add GET support for test results endpoint

### DIFF
--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -570,6 +570,35 @@ A series has then ``n`` revisions, ``n`` going from ``1`` to ``version``.
                     be used for full logs, which can be rather large.
 
 
+.. http:get:: /api/1.0/series/(int: series_id)/revisions/(int: version)/test-results/
+
+     Get test results for this revision.
+
+    .. sourcecode:: http
+
+        GET /api/1.0/series/47/revisions/1/test-results/ HTTP/1.1
+
+        [
+         {
+             "date": "2017-08-09T23:00:03.529",
+             "state": "pending",
+             "summary": "total: 0 errors, 0 warnings, 10 lines checked"
+             "test_name": "checkpatch.pl",
+             "url": "http://jenkins.example.com/logs/47/checkpatch.log"
+         },
+         {
+             "date": "2017-08-09T23:00:05.551",
+             "state": "warning",
+             "summary": "total: 0 errors, 2 warnings, 20 passes"
+             "test_name": "BAT",
+             "url": "http://jenkins.example.com/logs/47/BAT.log"
+         }
+        ]
+
+
+    :<json date: Date when the results were posted to the patchwork (ISO 8061).
+
+
 .. http:post /api/1.0/series/(int: series_id)/revisions/(int: version)/newrevision/
 
     Create a new ``series-new-revision`` event for this revision. This can be

--- a/patchwork/serializers.py
+++ b/patchwork/serializers.py
@@ -266,6 +266,7 @@ class TestResultSerializer(serializers.Serializer):
     state = ValueChoiceField(choices=TestState.STATE_CHOICES)
     url = serializers.URLField(required=False, allow_none=True)
     summary = serializers.CharField(required=False, allow_none=True)
+    date = serializers.CharField(required=False, allow_none=True)
 
     def resolve_fields(self, validated_data):
         project = self.context['project']

--- a/patchwork/views/api.py
+++ b/patchwork/views/api.py
@@ -488,6 +488,18 @@ class RevisionResultViewSet(viewsets.ViewSet, ResultMixin):
 
         return response
 
+    def list(self, request, series_pk, version_pk):
+        rev = get_object_or_404(SeriesRevision, series=series_pk,
+                                version=version_pk)
+
+        test_results = TestResult.objects \
+            .filter(revision=rev, patch=None) \
+            .order_by('test__name').select_related('test')
+
+        serializer = TestResultSerializer(test_results, many=True)
+
+        return Response(serializer.data)
+
 
 class PatchFilter(django_filters.FilterSet):
 


### PR DESCRIPTION
So far test results could be only posted via the REST API.

This patch add GET verb support to the following endpoint
/api/1.0/series/(int: series_id)/revisions/(int: version)/test-results/
allowing clients to also query the results.