### PR TITLE
rest: Use "human name" for the series

### DIFF
--- a/patchwork/serializers.py
+++ b/patchwork/serializers.py
@@ -152,6 +152,7 @@ class SeriesSerializer(PatchworkModelSerializer):
     test_state = serializers.SerializerMethodField('get_test_state')
     state = serializers.SerializerMethodField('get_state')
     state_summary = serializers.SerializerMethodField('get_state_summary')
+    name = serializers.SerializerMethodField('get_human_name')
 
     def get_version(self, obj):
         if not obj.last_revision:
@@ -170,6 +171,9 @@ class SeriesSerializer(PatchworkModelSerializer):
         if state is not None:
             return dict(TestState.STATE_CHOICES)[state]
         return state
+
+    def get_human_name(self, obj):
+        return obj.human_name()
 
     def get_state(self, obj):
         if not obj.last_revision:

--- a/patchwork/tests/test_rest.py
+++ b/patchwork/tests/test_rest.py
@@ -303,9 +303,9 @@ class APITest(APITestBase):
     def testNumQueries(self):
         # using the related=expand parameter shouldn't make the number of
         # queries explode.
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             self.get('/projects/%(project_id)s/series/')
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             self.get('/projects/%(project_id)s/series/',
                      params={'related': 'expand'})
 


### PR DESCRIPTION
Currently all series without a cover letter are visible both through the
API and the web interface (which uses the API) as a
"Series without cover letter".

That makes the series hard to identify and takes a toll on developers'
and maintainers' time.

We already have means of generating friendlier titles in form
"series starting with THE FIRST PATCH NAME"
that was created for seeding out results,

So let's reuse it in the API for consistency.

Also bump query number in one of the related tests, became this patch
introduces an additional one.