### PR TITLE
models.Person: Quote name in email_name() properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise # https://github.com/travis-ci/travis-ci/issues/8331
 language: python
 python:
     - 2.7

--- a/patchwork/models.py
+++ b/patchwork/models.py
@@ -56,7 +56,7 @@ class Person(models.Model):
 
     def email_name(self):
         if (self.name):
-            return "%s <%s>" % (self.name, self.email)
+            return "\"%s\" <%s>" % (self.name, self.email)
         else:
             return self.email
 

--- a/patchwork/tests/test_person.py
+++ b/patchwork/tests/test_person.py
@@ -57,3 +57,10 @@ class SubmitterCompletionTest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content.decode())
         self.assertEqual(len(data), 5)
+
+
+class PersonModelTest(TestCase):
+
+    def testEmailNameQuoted(self):
+        p = Person(name="Name, Test", email="test@example.com")
+        self.assertEqual(p.email_name(), '"Name, Test" <test@example.com>')


### PR DESCRIPTION
If a person sends emails with their name using 'Last, First' notation,
then when we compose email_name() it looks like:

'Last, First <address@email.tld>'

When results are sent out the above appended directly to the recipient
fields, resulting in emails being sent to 'Last@localhost' and 'First
<address@email.tld>'.

Let's fix that by always putting name in the quotes, like that:

'"Last, First" <address@email.tld>'