### PR TITLE
permissions: add a fast path for non-authenticated users

### DIFF
--- a/patchwork/permissions.py
+++ b/patchwork/permissions.py
@@ -25,6 +25,9 @@ class Can:
         self.user = user
 
     def edit(self, obj):
+        if not self.user.is_authenticated():
+            return False
+
         can = self
         if isinstance(obj, Project):
             project = obj


### PR DESCRIPTION
patchwork returns a following back-trace without this patch:

Internal Server Error: /patch/858/
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/srv/patchwork/lib/apache2/../../patchwork/views/patch.py", line 34, in patch
    editable = Can(request.user).edit(patch)
  File "/srv/patchwork/lib/apache2/../../patchwork/permissions.py", line 38, in edit
    can.edit(patch.project)))
  File "/srv/patchwork/lib/apache2/../../patchwork/permissions.py", line 32, in edit
    project in self.user.profile.maintainer_projects.all())
  File "/usr/lib/python2.7/site-packages/django/utils/functional.py", line 226, in inner
    return func(self._wrapped, *args)
AttributeError: 'AnonymousUser' object has no attribute 'profile'

Fixes: e876b0685241 ("permissions: Introduce central point for defining permissions")